### PR TITLE
Set a timeout on main HTTP calls

### DIFF
--- a/library/ak_closure_talk/main.py
+++ b/library/ak_closure_talk/main.py
@@ -117,6 +117,7 @@ class ArknightsClosureStore:
                         GITHUB_RAW_LINK.format(path=f"resources/ak/characters/{quote(image)}.webp"),
                         proxy=proxy,
                         verify=False,
+                        timeout=10.0,
                     )
                     with (char_path / image_path).open("wb+") as f:
                         f.write(resp.read())
@@ -130,6 +131,7 @@ class ArknightsClosureStore:
                 GITHUB_RAW_LINK.format(path="resources/ak/char.json"),
                 proxy=proxy,
                 verify=False,
+                timeout=10.0,
             )
             with (self.base_path / "char.json").open("wb+") as f:
                 f.write(resp.read())

--- a/library/sk_autosign/crypto.py
+++ b/library/sk_autosign/crypto.py
@@ -193,6 +193,7 @@ def get_d_id():
             "organization": SM_CONFIG["organization"],
             "os": "web",  # 固定值
         },
+        timeout=10.0,
     )
 
     resp = response.json()


### PR DESCRIPTION
I noticed this while tracing through library/ak_closure_talk/main.py. Set a timeout on main HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.